### PR TITLE
Change JCenter URL to be https

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ ext.mainClass = 'com.emc.ecs.tool.BucketWipe'
 buildscript {
     repositories {
         jcenter {
-            url "http://jcenter.bintray.com/"
+            url "https://jcenter.bintray.com/"
         }
     }
     dependencies {


### PR DESCRIPTION
Changes the JCenter URL to be `https` to be inline with new JCenter Policies.

**Testing**
```
$ gradle build

> Task :javadoc
bucket-wipe\src\main\java\com\emc\ecs\tool\EnhancedThreadPoolExecutor.java:92: warning: no @param for task
    public Future blockingSubmit(Runnable task) {
                  ^
bucket-wipe\src\main\java\com\emc\ecs\tool\EnhancedThreadPoolExecutor.java:92: warning: no @return
    public Future blockingSubmit(Runnable task) {
                  ^
bucket-wipe\src\main\java\com\emc\ecs\tool\EnhancedThreadPoolExecutor.java:117: warning: no @param for newPoolSize
    public void resizeThreadPool(int newPoolSize) {
                ^
3 warnings

Deprecated Gradle features were used in this build, making it incompatible with Gradle 5.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/4.10.2/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 9s
11 actionable tasks: 11 executed
```